### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete regular expression for hostnames

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -4,7 +4,7 @@ const tiktok_photo = require('./plugins/tiktok_photo');
 
 async function handler(bot, msg) {
   const From = msg.chat.id;
-  const body = /^https:\/\/.*tiktok\.com\/.+/;
+  const body = /^https:\/\/(?:[\w-]+\.)?tiktok\.com\/.+/;
 
   if (body.test(msg.text)) {
     const url = msg.text;


### PR DESCRIPTION
Potential fix for [https://github.com/hostinger-bot/tiktok-tele-bot/security/code-scanning/3](https://github.com/hostinger-bot/tiktok-tele-bot/security/code-scanning/3)

To fix the problem, the code should accurately check that the given text starts with a valid TikTok URL, specifically ensuring that `tiktok.com` is the domain name (optionally prefixed by things like `www.` or `vm.`). The regular expression should specifically match URLs starting with `https://`, followed by an optional subdomain, and then `tiktok.com/`, with proper escaping of '.' as a metacharacter. The change involves updating the regex on line 7 of `handler.js` to `/^https:\/\/(?:[\w-]+\.)?tiktok\.com\/.+/`. 

No other code changes are required, as the logic depends on this regex.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
