### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,12 @@ const axios = require('axios');
 const { BOT_TOKEN, AI_API_URL, AI_SYSTEM_PROMPT } = require('./config');
 const { version } = require('./package.json');
 const handler = require('./handler');
+const { URL } = require('url');
+const allowedTikTokHosts = [
+  'tiktok.com',
+ 'www.tiktok.com',
+ 'vt.tiktok.com'
+];
 
 const bot = new TelegramBot(BOT_TOKEN, { polling: true });
 let Start = new Date();
@@ -553,7 +559,15 @@ bot.on('message', async (msg) => {
 
   try {
     if (isStrictTikTokUrl && text === msg.text.trim()) {
-      if (!text.includes('vt.tiktok.com') && !text.includes('tiktok.com')) {
+      let isValidHost = false;
+      try {
+        const parsedUrl = new URL(text);
+        // If host is EXACTLY one of the allowed TikTok hosts
+        isValidHost = allowedTikTokHosts.includes(parsedUrl.host);
+      } catch (parseErr) {
+        isValidHost = false;
+      }
+      if (!isValidHost) {
         await bot.sendMessage(chatId, getMessage(lang, 'invalid_url'), { parse_mode: 'Markdown' });
         logs('warning', 'Invalid TikTok URL', { ChatID: chatId, URL: text });
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/hostinger-bot/tiktok-tele-bot/security/code-scanning/2](https://github.com/hostinger-bot/tiktok-tele-bot/security/code-scanning/2)

To correctly verify that a received URL is actually a permitted TikTok URL, we should parse the URL using a standard library (such as Node.js's built-in `url` module or WHATWG `URL` class), and check its hostname. We should maintain a whitelist of allowed TikTok hostnames, such as `'tiktok.com'`, `'www.tiktok.com'`, `'vt.tiktok.com'`, etc., and ensure that the URL's host matches exactly or is an allowed subdomain.  
The code to check inclusion of 'tiktok.com' (`text.includes('tiktok.com')`) on line 556 should be replaced with logic that parses the `text` as a URL, extracts its hostname, and verifies that the hostname is in the allowed list.  
We'll need to add an import (`const { URL } = require('url')`), define the whitelist hostnames, and replace the relevant condition.  
All edits remain in `main.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
