### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { PORT } = require('./config');
-const { bot } = require('./main');
+require('./main');
 
 const app = express();
 


### PR DESCRIPTION
The best way to fix the problem is to remove the destructuring and imported unused variable `bot` from line 3 entirely. If the side effects of requiring `"./main"` are required, the code should use `require('./main');` without destructuring—otherwise, if even that import is unused, the line should be removed. Based on the code snippet shown, only `bot` is unused; so we should remove `{ bot }` from the import, and, if necessary for side effects, keep a plain `require('./main');`.

Thus:  
- Replace `const { bot } = require('./main');` with either `require('./main');` (to preserve side effects) or remove it entirely (if absolutely sure no side effects are needed).
- Place this code fix at line 3.
- No other code or functionality is affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._